### PR TITLE
Add support for sharing an ORT session

### DIFF
--- a/src/onnxruntime_utils.cc
+++ b/src/onnxruntime_utils.cc
@@ -493,5 +493,22 @@ CompareDimsSupported(
   return nullptr;  // success
 }
 
+std::string
+GetInstanceGroupName(
+    const std::string& model_name, const std::string& instance_name)
+{
+  std::regex groupNameRegex('(' + model_name + '_' + "[0-9]" + ')');
+  std::smatch groupName;
+
+  if (model_name.empty() || instance_name.empty()) {
+    return "";
+  }
+
+  if (std::regex_search(instance_name, groupName, groupNameRegex)) {
+    return groupName.str(1);
+  }
+
+  return "";
+}
 
 }}}  // namespace triton::backend::onnxruntime

--- a/src/onnxruntime_utils.h
+++ b/src/onnxruntime_utils.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <onnxruntime_c_api.h>
+#include <regex>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -148,5 +149,8 @@ TRITONSERVER_Error* CompareDimsSupported(
     const std::string& model_name, const std::string& tensor_name,
     const std::vector<int64_t>& model_shape, const std::vector<int64_t>& dims,
     const int max_batch_size, const bool compare_exact);
+
+std::string GetInstanceGroupName(
+    const std::string& model_name, const std::string& instance_name);
 
 }}}  // namespace triton::backend::onnxruntime


### PR DESCRIPTION
> see: https://github.com/triton-inference-server/onnxruntime_backend/pull/141

For every instance in a model instance group a new ORT session is created. This code adds support to share a session per instance group.
This support can be enabled by defining 'share_session' to true in triton model config "parameters". Example:
parameters [
.....
  {
    key: "share_session"
    value: {string_value: "true"}
  }
]

This is a global parameter and cannot be defined per instance group. The user should determine if the parameter makes sense for their setup.